### PR TITLE
Swallow title lookup errors

### DIFF
--- a/lib/link_parser.rb
+++ b/lib/link_parser.rb
@@ -39,7 +39,7 @@ class LinkParser
     title = title_from_page(url)
     return title if title != ''
     last_path_segment(url)
-  rescue
+  rescue IOError
     last_path_segment(url)
   end
 

--- a/lib/link_parser.rb
+++ b/lib/link_parser.rb
@@ -39,6 +39,8 @@ class LinkParser
     title = title_from_page(url)
     return title if title != ''
     last_path_segment(url)
+  rescue
+    last_path_segment(url)
   end
 
   private

--- a/spec/unit/link_parser_spec.rb
+++ b/spec/unit/link_parser_spec.rb
@@ -88,6 +88,13 @@ RSpec.describe LinkParser, :vcr do
       end
     end
 
+    context 'when the request for the title errors' do
+      let(:url) { 'https://www.thegamer.com/skyrim-stealth-archer-build-guide/' }
+      it 'uses the last path segment as the title' do
+        expect(link.title).to eq('Skyrim Stealth Archer Build Guide')
+      end
+    end
+
     # original has been fixed
     # context 'when there are multiple title tags foolishly' do
     #   let(:url) { 'https://babeljs.io/docs/usage/polyfill/' }


### PR DESCRIPTION
If looking up the title fails for any reason, don't fail the request, just use the last URL segment as though there were no title tag.